### PR TITLE
Add release crit cola

### DIFF
--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -2733,11 +2733,16 @@ Action OnGameEvent(Event event, const char[] name, bool dontbroadcast) {
 				GetItemVariant(Wep_SodaPopper) == 0 &&
 				players[client].is_under_hype
 			) {
-				bool has_lunchbox = (player_weapons[client][Wep_Bonk] || player_weapons[client][Wep_CritCola]);
-				if (has_lunchbox)
-				{
+				if (player_weapons[client][Wep_SodaPopper]) {
+					if (
+						player_weapons[client][Wep_Bonk] ||
+						player_weapons[client][Wep_CritCola]
+					){
+						players[client].is_under_hype = false;
+						TF2_AddCondition(client, TFCond_CritHype, 11.0, 0);
+					}
+				} else {
 					players[client].is_under_hype = false;
-					TF2_AddCondition(client, TFCond_CritHype, 11.0, 0);
 				}
 			}
 		}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1753,16 +1753,18 @@ public void TF2_OnConditionRemoved(int client, TFCond condition) {
 			// Generate a random integer from the set {3, 5, 6, 7}
 			int randomInt = GetRandomInt(1, 4); // Generate a number between 1 and 4
 
-			// Adjust the random value to select 3, 5, 6, or 7
-			if (randomInt == 1) {
-				randomInt = 3;
-			} else if (randomInt == 2) {
-				randomInt = 5;
-			} else if (randomInt == 3) {
-				randomInt = 6;
-			} else {
-				randomInt = 7;
+			// Adjust the random value to select 3, 5, 6, or 7	
+			switch(randomInt) {
+				case 1:
+					randomInt = 3;
+				case 2:
+					randomInt = 5;
+				case 3:
+					randomInt = 6;
+				case 4:
+					randomInt = 7;
 			}
+
 			// PrintToChatAll("randomInt: %i", randomInt); //debug
 			// Format the string with the chosen number
 			char soundString[64];

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1748,7 +1748,6 @@ public void TF2_OnConditionRemoved(int client, TFCond condition) {
 			(GetItemVariant(Wep_CritCola) == 3) &&
 			TF2_GetPlayerClass(client) == TFClass_Scout &&
 			condition == TFCond_CritCola
-			
 		) {
 			// Generate a random integer from the set {3, 5, 6, 7}
 			int randomInt = GetRandomInt(1, 4); // Generate a number between 1 and 4

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1750,13 +1750,31 @@ public void TF2_OnConditionRemoved(int client, TFCond condition) {
 			condition == TFCond_CritCola
 			
 		) {
-			int randomInt = GetRandomInt(1,7);
+			// Generate a random integer from the set {3, 5, 6, 7}
+			int randomInt = GetRandomInt(1, 4); // Generate a number between 1 and 4
+
+			// Adjust the random value to select 3, 5, 6, or 7
+			if (randomInt == 1) {
+				randomInt = 3;
+			} else if (randomInt == 2) {
+				randomInt = 5;
+			} else if (randomInt == 3) {
+				randomInt = 6;
+			} else {
+				randomInt = 7;
+			}
+			// PrintToChatAll("randomInt: %i", randomInt); //debug
+			// Format the string with the chosen number
 			char soundString[64];
 			Format(soundString, sizeof(soundString), "Scout.InvincibleNotReady%02d", randomInt);
+
+			// Emit the sound using the constructed string
 			EmitGameSoundToAll(soundString, client);
-			// This is not supposed to play when Scout touches the resupply cabinet, but this bug is good for quickly testing.
+
+			// This is not supposed to play when Scout touches the resupply cabinet, but this bug is good for testing.
 			// There are 7 Scout.InvicibleNotReady0# game sounds. 
 			// The TF2 wiki mentions only using 3, 5, 6, and 7 in which Scout says something when the crit a cola effects are gone.
+			// Also there are unknown voice lines where Scout deeply exhales and inhales after the buff wears off. I cannot seem to find it.
 			
 		}
 	}

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -1742,6 +1742,26 @@ public void TF2_OnConditionRemoved(int client, TFCond condition) {
 	}
 
 	{
+		// when release crit-a-cola minicrit condition is removed, play Scout voicelines
+		if (
+			ItemIsEnabled(Wep_CritCola) &&
+			(GetItemVariant(Wep_CritCola) == 3) &&
+			TF2_GetPlayerClass(client) == TFClass_Scout &&
+			condition == TFCond_CritCola
+			
+		) {
+			int randomInt = GetRandomInt(1,7);
+			char soundString[64];
+			Format(soundString, sizeof(soundString), "Scout.InvincibleNotReady%02d", randomInt);
+			EmitGameSoundToAll(soundString, client);
+			// This is not supposed to play when Scout touches the resupply cabinet, but this bug is good for quickly testing.
+			// There are 7 Scout.InvicibleNotReady0# game sounds. 
+			// The TF2 wiki mentions only using 3, 5, 6, and 7 in which Scout says something when the crit a cola effects are gone.
+			
+		}
+	}
+
+	{
 		// buffalo steak sandvich marked-for-death effect removal
 		if (
 			ItemIsEnabled(Wep_BuffaloSteak) &&

--- a/scripting/reverts.sp
+++ b/scripting/reverts.sp
@@ -430,6 +430,8 @@ public void OnPluginStart() {
 	ItemDefine("cozycamper","CozyCamper_0", CLASSFLAG_SNIPER, Wep_CozyCamper);
 #endif
 	ItemDefine("critcola", "CritCola_0", CLASSFLAG_SCOUT, Wep_CritCola);
+	ItemVariant(Wep_CritCola, "CritCola_1");
+	ItemVariant(Wep_CritCola, "CritCola_2");
 #if defined MEMORY_PATCHES
 	ItemDefine("dalokohsbar", "DalokohsBar_0", CLASSFLAG_HEAVY, Wep_Dalokoh);
 #endif
@@ -1779,6 +1781,17 @@ public Action TF2_OnRemoveCond(int client, TFCond &condition, float &timeleft, i
 			}
 		}
 	}
+	{
+		// pre-inferno crit-a-cola mark-for-death on expire
+		if (
+			GetItemVariant(Wep_CritCola) == 1 &&
+			TF2_GetPlayerClass(client) == TFClass_Scout &&
+			condition == TFCond_CritCola &&
+			GetEntPropFloat(client, Prop_Send, "m_flEnergyDrinkMeter") <= 0.0
+		) {
+			TF2_AddCondition(client, TFCond_MarkedForDeathSilent, 2.0, 0);
+		}
+	}
 	return Plugin_Continue;
 }
 
@@ -1902,7 +1915,9 @@ public Action TF2Items_OnGiveNamedItem(int client, char[] class, int index, Hand
 		case 163: { if (ItemIsEnabled(Wep_CritCola)) {
 			TF2Items_SetNumAttributes(itemNew, 2);
 			TF2Items_SetAttribute(itemNew, 0, 814, 0.0); // no mark-for-death on attack
-			TF2Items_SetAttribute(itemNew, 1, 798, 1.10); // +10% damage vulnerability while under the effect
+			// +25% or +10% damage vulnerability while under the effect, depending on variant
+			float vuln = GetItemVariant(Wep_CritCola) == 2 ? 1.25 : 1.10;
+			TF2Items_SetAttribute(itemNew, 1, 798, vuln);
 		}}
 		case 231: { if (ItemIsEnabled(Wep_Darwin)) {
 			bool dmg_mods = GetItemVariant(Wep_Darwin) == 0;

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -503,6 +503,14 @@
 	{
 		"en"	"Reverted to pre-matchmaking, +25%% movespeed, +10%% damage taken, no mark-for-death on attack"
 	}
+	"CritCola_1"
+	{
+		"en"	"Reverted to pre-inferno, +25%% movespeed, +10%% damage taken, mark-for-death after effect ends"
+	}
+	"CritCola_2"
+	{
+		"en"	"Reverted to pre-Smissmas 2013, +25%% movespeed, +25%% damage taken, no mark-for-death on attack"
+	}
 	"DalokohsBar_0"
 	{
 		"en"	"Reverted to Gun Mettle update, can now overheal to 400 hp again"

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -503,6 +503,18 @@
 	{
 		"en"	"Reverted to pre-matchmaking, +25%% movespeed, +10%% damage taken, no mark-for-death on attack"
 	}
+	"CritCola_1"
+	{
+		"en"	"Reverted to pre-inferno, +25%% movespeed, +10%% damage taken, 2 sec mark-for-death after effect ends"
+	}
+	"CritCola_2"
+	{
+		"en"	"Reverted to pre-Smissmas 2013, +25%% movespeed, +25%% damage taken, no mark-for-death on attack"
+	}
+	"CritCola_3"
+	{
+		"en"	"Reverted to release, no movespeed bonus, minicrits on damage taken, buff lasts 6 seconds"
+	}	
 	"DalokohsBar_0"
 	{
 		"en"	"Reverted to Gun Mettle update, can now overheal to 400 hp again"

--- a/translations/reverts.phrases.txt
+++ b/translations/reverts.phrases.txt
@@ -505,7 +505,7 @@
 	}
 	"CritCola_1"
 	{
-		"en"	"Reverted to pre-inferno, +25%% movespeed, +10%% damage taken, mark-for-death after effect ends"
+		"en"	"Reverted to pre-inferno, +25%% movespeed, +10%% damage taken, 2 sec mark-for-death after effect ends"
 	}
 	"CritCola_2"
 	{


### PR DESCRIPTION
### Summary of changes
Release Crit-a-Cola
Reverted to release, no movespeed bonus, minicrits on damage taken, buff lasts 6 seconds

**You should try testing this again on your end**

### Testing Attestation
- [x] - This change has been tested
- [ ] - This change has not been tested, reasoning below

### Description of testing
Itemtest on dedicated server offline with bots, seems to work

### Other Info
Voicelines do not play when the buff duration ends, so I re-added voicelines (not the exact voicelines but they will do for now until I can find the exact voicelines). The other voicelines I'm trying to look for are the voicelines where Scout breathes heavily. Maybe its in the game's source code or in the gamesounds somewhere, I'm not sure where.
